### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -23,8 +23,8 @@ toggleSettings	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################
-ON  LITERAL1
-OFF LITERAL1
+ON	LITERAL1
+OFF	LITERAL1
 NORMAL_MODE	LITERAL1
 TOGGLE_MODE	LITERAL1
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords